### PR TITLE
added cloudFront invalidation command to npm/yarn scripts 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build:bundle": "babel-node ./tools/build.js",
     "s3:clean": "aws s3 rm s3://nj2jp-react --recursive",
     "s3:deploy": "aws s3 sync dist/ s3://nj2jp-react",
-    "deploy-s3": "npm-run-all s3:clean s3:deploy",
+    "cf:invalidate": "babel-node ./tools/cf_invalidate_script.js",
+    "deploy-s3-invalidate-cf": "npm-run-all s3:clean s3:deploy cf:invalidate",
     "build": "NODE_ENV=production npm-run-all build:bundle copy:assets open:dist",
     "analyze-bundle": "NODE_ENV=production babel-node ./tools/analyzeBundle.js"
   },

--- a/tools/cf_invalidate_script.js
+++ b/tools/cf_invalidate_script.js
@@ -1,0 +1,14 @@
+// Helper script to invalidate cache in cloudFront.
+// Store your cloudFront DISTRIBUTIONID in .env in root of the project.
+
+import { exec } from 'child_process';
+import dotenv from 'dotenv';
+
+dotenv.load({ silent: true });
+
+console.log(dotenv);
+
+exec(`aws cloudfront create-invalidation --distribution-id ${process.env.DISTRIBUTIONID} --paths '/*'`, function (err, stdout) {
+  if (err) throw err;
+  console.log(stdout);
+});


### PR DESCRIPTION
Invalidating is removing objects from the CloudFront edge caches before it expires. So, we have to remove the objects from cache when we deploy new files to S3. I have written about invalidation in CF [here](https://github.com/lakshmantgld/route53-CloudFront-S3-Setup/blob/master/readmeFiles/invalidateInCF.md). 

Note:
- I have hardcoded the distributionID. Can we use **dotenv** for this ?

